### PR TITLE
Loading placeholder images

### DIFF
--- a/app/api/hypercerts/[hypercertId]/image/route.ts
+++ b/app/api/hypercerts/[hypercertId]/image/route.ts
@@ -88,7 +88,7 @@ export async function GET(
       });
     } catch (error) {
       console.error(`Error parsing image data: ${error}`);
-      return placeholderImageResponse(request);
+      return placeholderImageRedirect(request);
     }
   } catch (error) {
     console.error(`Error fetching image metadata: ${error}`);


### PR DESCRIPTION
Send a redirect to the browser instead of fetching the placeholder image behind the scenes.