### PR TITLE
fix(wallet-profile): :fire: Remove unused Settings link

### DIFF
--- a/components/wallet-profile.tsx
+++ b/components/wallet-profile.tsx
@@ -126,11 +126,6 @@ const WalletProfile = ({
               Evaluators
             </DropdownMenuItem>
           </Link>
-          <Link href={`/profile/${address}/settings`}>
-            <DropdownMenuItem className="cursor-pointer">
-              Settings
-            </DropdownMenuItem>
-          </Link>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DisconnectDialog


### PR DESCRIPTION
## Key changes
- Removed unused "Settings" link from wallet profile dropdown menu

## Detailed changes

### Commits
- [ff8f4393](https://github.com/hypercerts-org/hypercert-app/commit/ff8f4393acc13000a3602dca54826dd4c19697b7): Remove unused Settings link

### Modified files
- `components/wallet-profile.tsx`

### Deleted
- Removed `<Link>` and `<DropdownMenuItem>` for Settings option

Closes #114