### PR TITLE
fix(gql): handle null response fetching allowlist records better

### DIFF
--- a/allowlists/getAllowListRecordsForAddressByClaimed.tsx
+++ b/allowlists/getAllowListRecordsForAddressByClaimed.tsx
@@ -24,8 +24,10 @@ export type AllowListRecord = ResultOf<typeof AllowListRecordFragment>;
 
 const query = graphql(
   `
-    query allowlistRecords($address: String) {
-      allowlistRecords(where: { user_address: { eq: $address } }) {
+    query allowlistRecords($address: String, $claimed: Boolean) {
+      allowlistRecords(
+        where: { user_address: { eq: $address }, claimed: { eq: $claimed } }
+      ) {
         count
         data {
           ...AllowListRecordFragment
@@ -36,9 +38,13 @@ const query = graphql(
   [AllowListRecordFragment],
 );
 
-export async function getAllowListRecordsForAddress(address: string) {
+export async function getAllowListRecordsForAddressByClaimed(
+  address: string,
+  claimed: boolean,
+) {
   const res = await request(HYPERCERTS_API_URL_GRAPH, query, {
     address,
+    claimed,
   });
 
   const allowlistRecords = res.allowlistRecords.data;

--- a/app/profile/[address]/hypercerts-tab-content.tsx
+++ b/app/profile/[address]/hypercerts-tab-content.tsx
@@ -1,5 +1,5 @@
 import { getHypercertsByCreator } from "@/hypercerts/getHypercertsByCreator";
-import { getAllowListRecordsForAddress } from "@/allowlists/getAllowListRecordsForAddress";
+import { getAllowListRecordsForAddressByClaimed } from "@/allowlists/getAllowListRecordsForAddressByClaimed";
 import HypercertWindow from "@/components/hypercert/hypercert-window";
 import { EmptySection } from "@/app/profile/[address]/sections";
 import UnclaimedHypercertsList from "@/components/profile/unclaimed-hypercerts-list";
@@ -24,22 +24,17 @@ const HypercertsTabContentInner = async ({
     ownerAddress: address,
   });
 
-  const allowlist = await getAllowListRecordsForAddress(address);
-
-  // TODO: Do this in the query. Currently it doesn't support multiple filters at the same time
-  const unclaimedHypercerts =
-    allowlist?.data.filter((item) => !item.claimed) || [];
-
-  const isEmptyAllowlist =
-    !allowlist ||
-    allowlist.count === 0 ||
-    !allowlist.data ||
-    !Array.isArray(allowlist.data);
+  const claimableHypercerts = await getAllowListRecordsForAddressByClaimed(
+    address,
+    true,
+  );
 
   const showCreatedHypercerts =
     createdHypercerts?.data && createdHypercerts.data.length > 0;
   const showOwnedHypercerts =
     ownedHypercerts?.data && ownedHypercerts.data.length > 0;
+  const showClaimableHypercerts =
+    claimableHypercerts?.data && claimableHypercerts.data.length > 0;
   const hypercertSubTabs = subTabs.filter(
     (tab) => tab.key.split("-")[0] === "hypercerts",
   );
@@ -49,7 +44,7 @@ const HypercertsTabContentInner = async ({
   > = {
     "hypercerts-created": createdHypercerts?.count ?? 0,
     "hypercerts-owned": ownedHypercerts?.count ?? 0,
-    "hypercerts-claimable": unclaimedHypercerts.length,
+    "hypercerts-claimable": claimableHypercerts?.count ?? 0,
   };
 
   return (
@@ -99,14 +94,16 @@ const HypercertsTabContentInner = async ({
           </section>
         ))}
 
-      {activeTab === "hypercerts-claimable" && (
-        <section className="pt-4">
+      {activeTab === "hypercerts-claimable" &&
+        (showClaimableHypercerts ? (
           <UnclaimedHypercertsList
-            unclaimedHypercerts={unclaimedHypercerts}
-            isEmptyAllowlist={isEmptyAllowlist}
+            unclaimedHypercerts={claimableHypercerts?.data}
           />
-        </section>
-      )}
+        ) : (
+          <section className="pt-4">
+            <EmptySection />
+          </section>
+        ))}
     </section>
   );
 };

--- a/app/profile/[address]/hypercerts-tab-content.tsx
+++ b/app/profile/[address]/hypercerts-tab-content.tsx
@@ -26,7 +26,7 @@ const HypercertsTabContentInner = async ({
 
   const claimableHypercerts = await getAllowListRecordsForAddressByClaimed(
     address,
-    true,
+    false,
   );
 
   const showCreatedHypercerts =

--- a/app/profile/[address]/page.tsx
+++ b/app/profile/[address]/page.tsx
@@ -16,7 +16,7 @@ export default function ProfilePage({
   searchParams: Record<string, string>;
 }) {
   const address = params.address;
-  const tab = searchParams?.tab || "hypercerts-created";
+  const tab = searchParams?.tab || "hypercerts-owned";
   const mainTab = tab?.split("-")[0] ?? "hypercerts";
 
   return (

--- a/components/profile/unclaimed-hypercert-claim-button.tsx
+++ b/components/profile/unclaimed-hypercert-claim-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AllowListRecord } from "@/allowlists/getAllowListRecordsForAddress";
+import { AllowListRecord } from "@/allowlists/getAllowListRecordsForAddressByClaimed";
 import { Button } from "../ui/button";
 import { useHypercertClient } from "@/hooks/use-hypercert-client";
 import { waitForTransactionReceipt } from "viem/actions";

--- a/components/profile/unclaimed-hypercert-list-item.tsx
+++ b/components/profile/unclaimed-hypercert-list-item.tsx
@@ -1,4 +1,4 @@
-import { AllowListRecord } from "@/allowlists/getAllowListRecordsForAddress";
+import { AllowListRecord } from "@/allowlists/getAllowListRecordsForAddressByClaimed";
 import Image from "next/image";
 import UnclaimedHypercertClaimButton from "./unclaimed-hypercert-claim-button";
 import TimeFrame from "../hypercert/time-frame";

--- a/components/profile/unclaimed-hypercerts-list.tsx
+++ b/components/profile/unclaimed-hypercerts-list.tsx
@@ -1,25 +1,28 @@
 import { EmptySection } from "@/app/profile/[address]/sections";
 import UnclaimedHypercertListItem from "./unclaimed-hypercert-list-item";
+import { AllowListRecord } from "@/allowlists/getAllowListRecordsForAddressByClaimed";
 
 export default async function UnclaimedHypercertsList({
-	unclaimedHypercerts,
-	isEmptyAllowlist,
+  unclaimedHypercerts,
 }: {
-	unclaimedHypercerts: any[];
-	isEmptyAllowlist: boolean;
+  unclaimedHypercerts: readonly AllowListRecord[];
 }) {
-	if (isEmptyAllowlist || unclaimedHypercerts.length === 0) {
-		return <EmptySection />;
-	}
+  if (unclaimedHypercerts.length === 0) {
+    return (
+      <section className="pt-4">
+        <EmptySection />
+      </section>
+    );
+  }
 
-	return (
-		<div className="grid grid-cols-[repeat(auto-fit,_minmax(270px,_1fr))] gap-4">
-			{unclaimedHypercerts.map((unclaimedHypercert, i) => (
-				<UnclaimedHypercertListItem
-					allowListRecordFragment={unclaimedHypercert}
-					key={i}
-				/>
-			))}
-		</div>
-	);
+  return (
+    <div className="grid grid-cols-[repeat(auto-fit,_minmax(270px,_1fr))] gap-4">
+      {unclaimedHypercerts.map((unclaimedHypercert, i) => (
+        <UnclaimedHypercertListItem
+          allowListRecordFragment={unclaimedHypercert}
+          key={i}
+        />
+      ))}
+    </div>
+  );
 }

--- a/hypercerts/getHypercertsByCreator.ts
+++ b/hypercerts/getHypercertsByCreator.ts
@@ -26,12 +26,9 @@ export async function getHypercertsByCreator({
   creatorAddress: string;
 }) {
   try {
-    console.log(creatorAddress);
     const queryRes = await request(HYPERCERTS_API_URL_GRAPH, query, {
       where: { creator_address: { eq: creatorAddress.toLowerCase() } },
     });
-
-    console.log(Object.keys(queryRes));
 
     if (!queryRes.hypercerts?.data) return undefined;
 

--- a/hypercerts/getHypercertsByOwner.ts
+++ b/hypercerts/getHypercertsByOwner.ts
@@ -31,8 +31,6 @@ export async function getHypercertsByOwner({
       where: { fractions: { owner_address: { eq: getAddress(ownerAddress) } } },
     });
 
-    console.log(Object.keys(queryRes));
-
     if (!queryRes.hypercerts?.data) return undefined;
 
     return {


### PR DESCRIPTION
* Updates `getAllowListRecordsForAddressByClaimed` to accept `claimed` param
* Updated Profile `page.tsx` to handle `null` response in data
* Cleaned up redundant logs