### PR TITLE
fix(hypercerts-window.tsx): allow for card to fill height of grid

### DIFF
--- a/components/hypercert/hypercert-window.tsx
+++ b/components/hypercert/hypercert-window.tsx
@@ -58,8 +58,8 @@ const HypercertWindow = ({
   const evaluationStatus = getEvaluationStatus(attestations);
 
   return (
-    <Link href={`/hypercerts/${hypercertId}`}>
-      <article className="transition-transform duration-300 hover:-translate-y-2 relative group bg-black/10 rounded-lg overflow-hidden">
+    <Link className="flex flex-col" href={`/hypercerts/${hypercertId}`}>
+      <article className="transition-transform duration-300 hover:-translate-y-2 relative group bg-black/10 rounded-lg overflow-hidden flex-1">
         <div className="h-[320px] w-full relative p-1">
           <Image
             src={`/api/hypercerts/${hypercertId}/image`}


### PR DESCRIPTION
added flex and flex-col to Link, this allows flex-1 on article to grow.

Note: This fix is impacted by changes made in beyondr-20240916 and should not be merged until after said PR and further testing.