### PR TITLE
Beyondr-20240928

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,10 +1,7 @@
-import ExploreChainFilterSelect from "@/components/explore/explore-chain-filter-select";
-import ExploreEvaluationsFilterSelect from "../../components/explore/explore-evaluations-filter-select";
+import ExploreFiltersLayout from "@/components/explore/explore-filters-layout";
 import ExploreList from "@/components/explore/explore-list";
-import ExploreOrderBySelect from "@/components/explore/explore-order-by-select";
 import ExploreSearchBar from "@/components/explore/explore-search-bar";
 import { Metadata } from "next";
-import { CurrencyButtons } from "@/components/currency-buttons";
 
 export const metadata: Metadata = {
   title: "Explore",
@@ -24,12 +21,7 @@ export default async function ExplorePageInner({
       </h1>
       <section className="flex flex-col lg:flex-row gap-4 justify-between max-w-screen">
         <ExploreSearchBar />
-        <div className="flex space-x-2 w-full">
-          <ExploreChainFilterSelect />
-          <ExploreEvaluationsFilterSelect />
-          <ExploreOrderBySelect />
-          <CurrencyButtons />
-        </div>
+        <ExploreFiltersLayout />
       </section>
       <ExploreList {...{ searchParams }} />
     </main>

--- a/components/explore/explore-chain-filter-select.tsx
+++ b/components/explore/explore-chain-filter-select.tsx
@@ -33,10 +33,10 @@ export default function ChainFilterSelect() {
       onValueChange={selectFilter}
       value={selectedValue}
     >
-      <SelectTrigger className="w-[130px]">
+      <SelectTrigger className="w-full">
         <SelectValue placeholder="All chains" />
       </SelectTrigger>
-      <SelectContent className="w-max">
+      <SelectContent className="w-full">
         <SelectItem value="all">All chains</SelectItem>
         {SUPPORTED_CHAINS.map((chain) => (
           <SelectItem key={chain.id} value={chain.id.toString()}>

--- a/components/explore/explore-evaluations-filter-select.tsx
+++ b/components/explore/explore-evaluations-filter-select.tsx
@@ -32,10 +32,10 @@ export default function ExploreEvaluationsFilterSelect() {
       onValueChange={selectFilter}
       value={selectedValue}
     >
-      <SelectTrigger className="w-[150px]">
+      <SelectTrigger className="w-full">
         <SelectValue placeholder="All chains" />
       </SelectTrigger>
-      <SelectContent className="w-max">
+      <SelectContent className="w-full">
         <SelectItem value="all">All Hypercerts</SelectItem>
         <SelectItem value="evaluated"> Only evaluated</SelectItem>
       </SelectContent>

--- a/components/explore/explore-filters-layout.tsx
+++ b/components/explore/explore-filters-layout.tsx
@@ -1,0 +1,35 @@
+"use client";
+import ExploreChainFilterSelect from "@/components/explore/explore-chain-filter-select";
+import ExploreEvaluationsFilterSelect from "@/components/explore/explore-evaluations-filter-select";
+import ExploreOrderBySelect from "@/components/explore/explore-order-by-select";
+import { CurrencyButtons } from "@/components/currency-buttons";
+import { useMediaQuery } from "@/hooks/use-media-query";
+
+const ExploreFiltersLayout = () => {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  if (isDesktop) {
+    return (
+      <section className="flex space-x-2 w-full max-w-screen-sm">
+        <ExploreChainFilterSelect />
+        <ExploreEvaluationsFilterSelect />
+        <ExploreOrderBySelect />
+        <CurrencyButtons />
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-2">
+      <div className="flex space-x-2 w-full">
+        <ExploreChainFilterSelect />
+        <ExploreEvaluationsFilterSelect />
+      </div>
+      <div className="flex space-x-2 w-full">
+        <CurrencyButtons />
+        <ExploreOrderBySelect />
+      </div>
+    </section>
+  );
+};
+
+export default ExploreFiltersLayout;

--- a/components/explore/explore-list.tsx
+++ b/components/explore/explore-list.tsx
@@ -64,7 +64,7 @@ async function ExploreListInner({
           Showing search results for: <b>{search}</b>
         </div>
       )}
-      <div className="grid grid-cols-[repeat(auto-fit,_minmax(16.875rem,_20rem))] gap-4 py-4">
+      <div className="grid grid-cols-[repeat(auto-fit,_minmax(16.875rem,_18.75rem))] gap-4 py-4">
         {hypercerts?.data?.map((hypercert) => {
           return (
             <HypercertWindow

--- a/components/explore/explore-list.tsx
+++ b/components/explore/explore-list.tsx
@@ -64,7 +64,7 @@ async function ExploreListInner({
           Showing search results for: <b>{search}</b>
         </div>
       )}
-      <div className="grid grid-cols-[repeat(auto-fit,_minmax(16.875rem,_18.75rem))] gap-4 py-4">
+      <div className="grid grid-cols-1 md:grid-cols-[repeat(auto-fit,_minmax(16.875rem,_18.75rem))] gap-4 py-4">
         {hypercerts?.data?.map((hypercert) => {
           return (
             <HypercertWindow

--- a/components/explore/explore-order-by-select.tsx
+++ b/components/explore/explore-order-by-select.tsx
@@ -28,7 +28,7 @@ export default function ExploreOrderBySelect() {
       onValueChange={orderBy}
       value={selectedValue}
     >
-      <SelectTrigger className="w-[220px]">
+      <SelectTrigger className="w-full">
         <SelectValue placeholder="Sort by" />
       </SelectTrigger>
       <SelectContent className="w-max">

--- a/components/global/mobile-nav.tsx
+++ b/components/global/mobile-nav.tsx
@@ -16,9 +16,11 @@ import { siteConfig } from "@/configs/site";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { ArrowUpRight, Menu } from "lucide-react";
 import Link from "next/link";
+import { useAccount } from "wagmi";
 
 const MobileNav = () => {
   const isDesktop = useMediaQuery("(min-width: 768px)");
+  const { address } = useAccount();
 
   if (isDesktop) return null;
 
@@ -35,17 +37,21 @@ const MobileNav = () => {
           <Link href={siteConfig.links.explore} className="w-full h-full">
             <MenubarItem>Explore</MenubarItem>
           </Link>
-          <MenubarSub>
-            <MenubarSubTrigger>Create</MenubarSubTrigger>
-            <MenubarSubContent>
-              <Link
-                href={siteConfig.links.createHypercert}
-                className="w-full h-full"
-              >
-                <MenubarItem>New Hypercert</MenubarItem>
-              </Link>
-            </MenubarSubContent>
-          </MenubarSub>
+          <Link
+            href={siteConfig.links.createHypercert}
+            className="w-full h-full"
+          >
+            <MenubarItem>New hypercert</MenubarItem>
+          </Link>
+          {address && (
+            <Link
+              key={siteConfig.links.profile}
+              href={`${siteConfig.links.profile}/${address}`}
+              className="w-full h-full"
+            >
+              <MenubarItem>Profile</MenubarItem>
+            </Link>
+          )}
           <MenubarSeparator />
           <Link
             href={siteConfig.links.docs}

--- a/components/global/navbar.tsx
+++ b/components/global/navbar.tsx
@@ -10,6 +10,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAccount } from "wagmi";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const Navbar = () => {
   const currentPath = usePathname();
@@ -56,7 +62,7 @@ const Navbar = () => {
             <span className="hover:underline">Create</span>
           </Link>
 
-          {address && (
+          {address ? (
             <Link
               key={siteConfig.links.profile}
               href={`${siteConfig.links.profile}/${address}`}
@@ -68,6 +74,22 @@ const Navbar = () => {
             >
               <span className="hover:underline">My hypercerts</span>
             </Link>
+          ) : (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className={`${buttonVariants({ variant: "link" })} opacity-50 cursor-help`}
+                  >
+                    My hypercerts
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[300px]">
+                  Click the &quot;Connect Wallet&quot; button and sign in to
+                  access your hypercerts
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
           <Link
             href={siteConfig.links.docs}


### PR DESCRIPTION
## Key changes
- Refactored explore page filters layout for improved responsiveness
- Updated mobile navigation links
- Added tooltip for "My hypercerts" link when user is not signed in
- Limited hypercert window expansion size in explore list

## Detailed changes

### Commits
- [163a7a6](https://github.com/hypercerts-org/hypercerts-app/commit/163a7a63a3c016b61ff944c3e2b83f01de7809ea): Add tooltip for "My hypercerts" link when user is not signed in
- [748247e](https://github.com/hypercerts-org/hypercerts-app/commit/748247ecf238e2e40f2ef6f107278db9856b7b89): Update responsive styles for filters on explore page
- [08f85fe](https://github.com/hypercerts-org/hypercerts-app/commit/08f85fec361cb31c86d4e2a7d17b5d1129c140c1): Update mobile nav links
- [393f608](https://github.com/hypercerts-org/hypercerts-app/commit/393f608840070ba61b6ea1ce2237cf3fe0f7f4ae): Limit hc-window expansion size to 300px in explore list

### New files
- `components/explore/explore-filters-layout.tsx`: New component for responsive filter layout

### Modified files
- `app/explore/page.tsx`: Simplified explore page layout
- `components/explore/explore-chain-filter-select.tsx`: Updated width styles
- `components/explore/explore-evaluations-filter-select.tsx`: Updated width styles
- `components/explore/explore-list.tsx`: Updated grid layout for better responsiveness
- `components/explore/explore-order-by-select.tsx`: Updated width styles
- `components/global/mobile-nav.tsx`: Restructured mobile navigation links
- `components/global/navbar.tsx`: Added tooltip for "My hypercerts" link

### Dependencies
- No changes to dependencies

Closes [UI] Always show "My hypercerts" #254
Closes [UI] Mobile view - explore #252