### PR TITLE
feat: evaluations cards in hypercert view

### DIFF
--- a/components/evaluation-list-item/comments.tsx
+++ b/components/evaluation-list-item/comments.tsx
@@ -1,4 +1,56 @@
-export default function Comments({ comments }: { comments?: string }) {
+"use client";
+
+import { truncate } from "lodash";
+import { useState } from "react";
+
+interface CommentsProps {
+  comments?: string;
+}
+
+export default function Comments({ comments }: CommentsProps) {
+  const [showFullComments, setShowFullComments] = useState(false);
   if (!comments) return null;
-  return <div>{comments}</div>;
+
+  // Truncate the comments to a maximum of 200 characters
+  // If the comments are longer than 200 characters, display the first 200 characters and add an ellipsis
+  // If the comments are shorter than 200 characters, display the full comments
+  // When the user clicks on 'Show full comments', display the full comments and replace the button with 'Show less'
+
+  // // generate random text for testing purposes
+  const text =
+    "Fuga qui expedita sit labore repellendus esse. Dolorem quisquam voluptates error provident. Saepe quisquam atque consequatur repudiandae cupiditate. Et cupiditate rem laboriosam eveniet ut praesentium aliquam. Et recusandae possimus excepturi est dolores laudantium sed. Tempora voluptatem quae fuga assumenda. Repudiandae commodi eius sapiente optio ducimus. In laboriosam rerum aut nam suscipit repudiandae et. Ab ut sequi inventore soluta eum suscipit molestiae unde. Sit et est modi. Totam dolores culpa consequuntur id esse impedit quo omnis.";
+
+  const truncatedComments = truncate(text, {
+    length: 200,
+    separator: "...",
+  });
+
+  const showFullCommentsButton = showFullComments ? (
+    <button
+      className="text-xs font-medium text-slate-700"
+      onClick={() => setShowFullComments(false)}
+    >
+      Show less
+    </button>
+  ) : (
+    <button
+      className="text-xs font-medium text-slate-700"
+      onClick={() => setShowFullComments(true)}
+    >
+      Show full comments
+    </button>
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2">
+        <div className="overflow-hidden text-sm text-slate-700">
+          {showFullComments ? text : truncatedComments}
+        </div>
+      </div>
+      <div>
+        <div className="flex justify-center">{showFullCommentsButton}</div>
+      </div>
+    </div>
+  );
 }

--- a/components/evaluation-list-item/comments.tsx
+++ b/components/evaluation-list-item/comments.tsx
@@ -11,16 +11,7 @@ export default function Comments({ comments }: CommentsProps) {
   const [showFullComments, setShowFullComments] = useState(false);
   if (!comments) return null;
 
-  // Truncate the comments to a maximum of 200 characters
-  // If the comments are longer than 200 characters, display the first 200 characters and add an ellipsis
-  // If the comments are shorter than 200 characters, display the full comments
-  // When the user clicks on 'Show full comments', display the full comments and replace the button with 'Show less'
-
-  // // generate random text for testing purposes
-  const text =
-    "Fuga qui expedita sit labore repellendus esse. Dolorem quisquam voluptates error provident. Saepe quisquam atque consequatur repudiandae cupiditate. Et cupiditate rem laboriosam eveniet ut praesentium aliquam. Et recusandae possimus excepturi est dolores laudantium sed. Tempora voluptatem quae fuga assumenda. Repudiandae commodi eius sapiente optio ducimus. In laboriosam rerum aut nam suscipit repudiandae et. Ab ut sequi inventore soluta eum suscipit molestiae unde. Sit et est modi. Totam dolores culpa consequuntur id esse impedit quo omnis.";
-
-  const truncatedComments = truncate(text, {
+  const truncatedComments = truncate(comments, {
     length: 200,
     separator: "...",
   });
@@ -45,7 +36,7 @@ export default function Comments({ comments }: CommentsProps) {
     <div className="flex flex-col gap-2">
       <div className="flex flex-col gap-2">
         <div className="overflow-hidden text-sm text-slate-700">
-          {showFullComments ? text : truncatedComments}
+          {showFullComments ? comments : truncatedComments}
         </div>
       </div>
       <div>

--- a/components/hypercert/evaluations-list.tsx
+++ b/components/hypercert/evaluations-list.tsx
@@ -6,7 +6,6 @@ import Evaluations from "../evaluation-list-item/evaluations";
 import FormattedDate from "../formatted-date";
 import { HypercertFull } from "../../hypercerts/fragments/hypercert-full.fragment";
 import Link from "next/link";
-import { Separator } from "../ui/separator";
 import Tags from "../evaluation-list-item/tags";
 import { UserIcon } from "../user-icon";
 
@@ -22,12 +21,15 @@ export default async function EvaluationsList({
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       {attestations.map((attestation, index) => {
         if (!attestation.attester) return null;
         const data: EvaluationData = attestation.data as EvaluationData;
         return (
-          <div key={attestation.uid} className="pb-5 flex flex-col gap-5">
+          <div
+            key={attestation.uid}
+            className="p-5 flex flex-col gap-5 rounded-lg border-[1.5px] border-slate-200 h-[500px] overflow-hidden"
+          >
             <FormattedDate seconds={attestation.creation_block_timestamp} />
 
             <Link
@@ -42,15 +44,16 @@ export default async function EvaluationsList({
                 </div>
               </div>
             </Link>
-            <Evaluations
-              basic={data.evaluate_basic}
-              work={data.evaluate_work}
-              properties={data.evaluate_properties}
-              contributors={data.evaluate_contributors}
-            />
-            <Tags tags={data.tags} />
-            <Comments comments={data.comments} />
-            {index < attestations.length - 1 && <Separator />}
+            <div className="flex-grow overflow-y-auto space-y-4">
+              <Evaluations
+                basic={data.evaluate_basic}
+                work={data.evaluate_work}
+                properties={data.evaluate_properties}
+                contributors={data.evaluate_contributors}
+              />
+              <Tags tags={data.tags} />
+              <Comments comments={data.comments} />
+            </div>
           </div>
         );
       })}


### PR DESCRIPTION
* Refactors evaluations list to represent evaluations using cards
* Truncate the comment at 200 chars and allow for expanding into a scrollable interface

![Screenshot 2024-09-30 at 14 37 29](https://github.com/user-attachments/assets/9cbc0664-db2e-4f62-9f3b-6733cc62858f)
![Screenshot 2024-09-30 at 14 37 23](https://github.com/user-attachments/assets/11d622bc-b521-468a-a763-46619f669527)
