### PR TITLE
Fix/fractional order form rounding errors (#317)

### DIFF
--- a/configs/hypercerts.ts
+++ b/configs/hypercerts.ts
@@ -8,6 +8,10 @@ const HYPERCERT_API_URL =
 export const HYPERCERTS_API_URL_REST = `${HYPERCERT_API_URL}/v1`;
 export const HYPERCERTS_API_URL_GRAPH = `${HYPERCERT_API_URL}/v1/graphql`;
 
-export const DEFAULT_NUM_FRACTIONS = parseUnits("1", 8);
+export const DEFAULT_NUM_FRACTIONS_DECIMALS = 8;
+export const DEFAULT_NUM_FRACTIONS = parseUnits(
+  "1",
+  DEFAULT_NUM_FRACTIONS_DECIMALS,
+);
 
 export const DEFAULT_DISPLAY_CURRENCY = "usd";

--- a/marketplace/hooks.tsx
+++ b/marketplace/hooks.tsx
@@ -414,7 +414,7 @@ export const useBuyFractionalMakerAsk = () => {
       totalUnitsInHypercert,
     }: {
       order: MarketplaceOrder;
-      unitAmount: string;
+      unitAmount: bigint;
       pricePerUnit: string;
       hypercertName?: string | null;
       totalUnitsInHypercert?: bigint;
@@ -473,7 +473,7 @@ export const useBuyFractionalMakerAsk = () => {
         takerOrder = hypercertExchangeClient.createFractionalSaleTakerBid(
           order,
           address,
-          unitAmount,
+          unitAmount.toString(),
           pricePerUnit,
         );
       } catch (e) {
@@ -492,7 +492,7 @@ export const useBuyFractionalMakerAsk = () => {
         );
       }
 
-      const totalPrice = BigInt(order.price) * BigInt(unitAmount);
+      const totalPrice = BigInt(order.price) * unitAmount;
       try {
         await setStep("ERC20");
         if (currency.address !== zeroAddress) {
@@ -566,11 +566,7 @@ export const useBuyFractionalMakerAsk = () => {
             <span>
               Congratulations, you successfully bought{" "}
               <b>
-                {calculateBigIntPercentage(
-                  BigInt(unitAmount),
-                  totalUnitsInHypercert,
-                )}
-                %
+                {calculateBigIntPercentage(unitAmount, totalUnitsInHypercert)}%
               </b>{" "}
               of <b>{hypercertName}</b>.
             </span>

--- a/marketplace/utils.ts
+++ b/marketplace/utils.ts
@@ -144,19 +144,3 @@ export const isTokenDividableBy = (
     (parseUnits(denominator || "1", currency.decimals) || BigInt(1));
   return remainder === BigInt(0);
 };
-
-export const getTotalPriceFromPercentage = (
-  pricePerPercent: bigint,
-  percentageAmount: number,
-) => {
-  if (percentageAmount < 0 || percentageAmount > 100) {
-    throw new Error("Percentage amount must be between 0 and 100");
-  }
-
-  const precision = 10 ** 16;
-
-  return (
-    (pricePerPercent * BigInt(Math.round(percentageAmount * precision))) /
-    BigInt(precision)
-  );
-};

--- a/test/marketplace/utils.test.ts
+++ b/test/marketplace/utils.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import {
-  getPricePerPercent,
-  getPricePerUnit,
-  getTotalPriceFromPercentage,
-} from "@/marketplace/utils";
+import { getPricePerPercent, getPricePerUnit } from "@/marketplace/utils";
 import { currenciesByNetwork } from "@hypercerts-org/marketplace-sdk";
 import { sepolia } from "viem/chains";
 
@@ -40,25 +36,6 @@ describe("utils", () => {
       //   getAddress("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"),
       // );
       // expect(getMinimumPrice("1", chainId, usdc.address)).to.eq(1n);
-    });
-  });
-
-  describe("getTotalPriceFromPercentage", () => {
-    it("should return the total price from percentage", () => {
-      expect(getTotalPriceFromPercentage(BigInt(1), 100)).to.eq(BigInt(100));
-      expect(() => getTotalPriceFromPercentage(BigInt(1), 200)).toThrowError();
-
-      expect(getTotalPriceFromPercentage(BigInt(1), 10)).to.eq(BigInt(10));
-      expect(getTotalPriceFromPercentage(BigInt(100), 0.1)).to.eq(BigInt(10));
-      expect(getTotalPriceFromPercentage(BigInt(10 ** 6), 0.00001)).to.eq(
-        BigInt(10),
-      );
-      expect(
-        getTotalPriceFromPercentage(BigInt(10 ** 12), 0.00000000001),
-      ).to.eq(BigInt(10));
-      expect(
-        getTotalPriceFromPercentage(BigInt(10 ** 16), 0.000000000000001),
-      ).to.eq(BigInt(10));
     });
   });
 });


### PR DESCRIPTION
* fix: prevent rounding errors in unit calculations by using DEFAULT_NUM_FRACTIONS precision

* fix: disable form when calculated number of units reaches 0, show price 0

* fix: calculate total price using units not percentage in fractional order form

* fix: remove magic number for number of decimals in hypercert units

* fix: remove redundant utility function getTotalPriceFromPercentage