### PR TITLE
Filter burned claim IDs

### DIFF
--- a/hypercerts/getAllHypercerts.ts
+++ b/hypercerts/getAllHypercerts.ts
@@ -155,7 +155,7 @@ export async function getAllHypercerts({
   chainId,
 }: GetAllHypercertsParams) {
   const res = await request(HYPERCERTS_API_URL_GRAPH, query, {
-    first: first + offset,
+    first,
     offset,
     sort: createOrderBy({ orderBy }),
     where: createFilter({ search, filter, chainId }),


### PR DESCRIPTION
This PR implement a ducttape method for filtering out burned hypercerts on the frontend. Because technically the explore page loads all claims, and not all fractions, burned claims are still displayed. Untill we have a robust mechanism implemented in our backend, we maintain this filter while queried hypercerts are parsed.

* Adds a filter set to `getAllHypercerts`
* Updates returned count based on filtered results