### PR TITLE
Construct SafeAPIKit instance differently for Filecoin Mainnet and Filecoin Calibration

### DIFF
--- a/hooks/useSafeAccounts.ts
+++ b/hooks/useSafeAccounts.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
-import SafeApiKit from "@safe-global/api-kit";
+import { SafeApiStrategyFactory } from "@/safe/SafeApiKitStrategy";
 
 import { useEnsStore } from "@/lib/ens-store";
 import { Account } from "@/lib/account-store";
@@ -17,9 +17,8 @@ export function useSafeAccounts() {
 
       setIsLoading(true);
       try {
-        const safeService = new SafeApiKit({
-          chainId: BigInt(chainId),
-        });
+        const safeService =
+          SafeApiStrategyFactory.getStrategy(chainId).createInstance();
 
         const { safes } = await safeService.getSafesByOwner(address);
         setSafeAccounts(

--- a/lib/evmClient.ts
+++ b/lib/evmClient.ts
@@ -95,10 +95,10 @@ export class EvmClientFactory {
   static getFirstAvailableUrl(chainId: number): string | undefined {
     return EvmClientFactory.getAllAvailableUrls(chainId)[0];
   }
-}
 
-export const getRpcUrl = (chainId: number): string => {
-  const url = EvmClientFactory.getFirstAvailableUrl(chainId);
-  if (!url) throw new Error(`No RPC URL available for chain ${chainId}`);
-  return url;
-};
+  static getRpcUrl(chainId: number): string {
+    const url = EvmClientFactory.getFirstAvailableUrl(chainId);
+    if (!url) throw new Error(`No RPC URL available for chain ${chainId}`);
+    return url;
+  }
+}

--- a/safe/SafeApiKitStrategy.ts
+++ b/safe/SafeApiKitStrategy.ts
@@ -1,0 +1,47 @@
+import SafeApiKit from "@safe-global/api-kit";
+
+export interface SafeApiKitStrategy {
+  createInstance(): SafeApiKit;
+}
+
+export class FilecoinMainnetStrategy implements SafeApiKitStrategy {
+  createInstance(): SafeApiKit {
+    return new SafeApiKit({
+      chainId: BigInt(314),
+      txServiceUrl: "https://transaction.safe.filecoin.io/api",
+    });
+  }
+}
+
+export class FilecoinTestnetStrategy implements SafeApiKitStrategy {
+  createInstance(): SafeApiKit {
+    console.log("chainId", BigInt(314159), typeof BigInt(314159));
+    return new SafeApiKit({
+      chainId: BigInt(314159),
+      txServiceUrl: "https://transaction-testnet.safe.filecoin.io/api",
+    });
+  }
+}
+
+export class DefaultSafeApiStrategy implements SafeApiKitStrategy {
+  constructor(private chainId: number) {}
+
+  createInstance(): SafeApiKit {
+    return new SafeApiKit({
+      chainId: BigInt(this.chainId),
+    });
+  }
+}
+
+export class SafeApiStrategyFactory {
+  static getStrategy(chainId: number): SafeApiKitStrategy {
+    switch (chainId) {
+      case 314:
+        return new FilecoinMainnetStrategy();
+      case 314159:
+        return new FilecoinTestnetStrategy();
+      default:
+        return new DefaultSafeApiStrategy(chainId);
+    }
+  }
+}

--- a/settings/SafeSettingsSigningStrategy.ts
+++ b/settings/SafeSettingsSigningStrategy.ts
@@ -1,5 +1,4 @@
 import { TypedDataEncoder } from "ethers";
-import SafeApiKit from "@safe-global/api-kit";
 import { type EIP712TypedData } from "@safe-global/types-kit";
 import Safe, {
   buildSignatureBytes,
@@ -12,6 +11,7 @@ import {
   hypercertApiSigningDomainSafe,
   type SafeApiSigningDomain,
 } from "@/configs/constants";
+import { SafeApiStrategyFactory } from "@/safe/SafeApiKitStrategy";
 
 import { SettingsSigningStrategy } from "./SettingsSigningStrategy";
 
@@ -72,7 +72,9 @@ export class SafeSettingsSigningStrategy extends SettingsSigningStrategy {
       provider: this.walletClient as unknown as Eip1193Provider,
       safeAddress: this.address,
     });
-    const apiKit = new SafeApiKit({ chainId: BigInt(this.chainId) });
+    const apiKit = SafeApiStrategyFactory.getStrategy(
+      this.chainId,
+    ).createInstance();
 
     const typedData = {
       domain: hypercertApiSigningDomainSafe(this.chainId, this.address),

--- a/test/lib/evmClient.test.ts
+++ b/test/lib/evmClient.test.ts
@@ -33,7 +33,7 @@ vi.mock("viem", () => ({
   http: vi.fn((url) => ({ url })),
 }));
 
-import { EvmClientFactory, getRpcUrl } from "@/lib/evmClient";
+import { EvmClientFactory } from "@/lib/evmClient";
 
 describe("EvmClient", () => {
   describe("EvmClientFactory", () => {
@@ -71,13 +71,13 @@ describe("EvmClient", () => {
 
   describe("getRpcUrl", () => {
     it("should return URL for supported chain", () => {
-      const url = getRpcUrl(11155111);
+      const url = EvmClientFactory.getRpcUrl(11155111);
       expect(url).toContain("alchemy.com");
       expect(url).toContain("mock-alchemy-key");
     });
 
     it("should throw error for unsupported chain", () => {
-      expect(() => getRpcUrl(999999)).toThrow(
+      expect(() => EvmClientFactory.getRpcUrl(999999)).toThrow(
         "No RPC URL available for chain 999999",
       );
     });
@@ -87,24 +87,24 @@ describe("EvmClient", () => {
 describe("RPC Providers", () => {
   describe("getRpcUrl", () => {
     it("should return Alchemy URL for supported chains", () => {
-      const url = getRpcUrl(11155111); // Sepolia
+      const url = EvmClientFactory.getRpcUrl(11155111); // Sepolia
       expect(url).toContain("alchemy.com");
       expect(url).toContain("alchemy-key");
     });
 
     it("should return Infura URL when Alchemy is not available", () => {
-      const url = getRpcUrl(42220); // Celo
+      const url = EvmClientFactory.getRpcUrl(42220); // Celo
       expect(url).toContain("infura.io");
       expect(url).toContain("infura-key");
     });
 
     it("should return Glif URL for Filecoin", () => {
-      const url = getRpcUrl(314159);
+      const url = EvmClientFactory.getRpcUrl(314159);
       expect(url).toContain("glif.io");
     });
 
     it("should throw error for unsupported chain", () => {
-      expect(() => getRpcUrl(999999)).toThrow(
+      expect(() => EvmClientFactory.getRpcUrl(999999)).toThrow(
         "No RPC URL available for chain 999999",
       );
     });


### PR DESCRIPTION
    Without this patch the instantiation of the Safe API Kit object fails
    due to the Filecoin networks requiring a specific Transaction Service
    URL. Usually these are determined by the SDK by providing it with just
    the chain id. Since the TX Service on Filecoin and Filecoin Calibration
    are hosted by a third party the SDK can't infer them.

    This adds a strategy that constructs the Safe API Kit instance
    differently based on the current chain id.
