### PR TITLE
fix: broken discord link in footer.tsx and site.ts

### DIFF
--- a/components/global/footer.tsx
+++ b/components/global/footer.tsx
@@ -22,7 +22,7 @@ const footerIcons = [
   },
   {
     label: "Discord",
-    url: "https://discord.gg/VVSyKg75",
+    url: "https://discord.gg/azPgDcSQWw",
     icon: "/social-icons/discord.svg",
   },
   {

--- a/configs/site.ts
+++ b/configs/site.ts
@@ -24,7 +24,7 @@ export const siteConfig: SiteConfig = {
     "Explore, mint, manage, buy, sell, and evaluate Hypercerts with ease.",
   localeDefault: "en",
   links: {
-    discord: "https://discord.gg/uExrjW4h7W",
+    discord: "https://discord.gg/azPgDcSQWw",
     twitter: "https://twitter.com/hypercerts",
     github: "https://github.com/hypercerts-org/",
     docs: "https://hypercerts.org/docs/",


### PR DESCRIPTION
replaced discord link in footer.tsx and site.ts with link that won't expire