### PR TITLE
Bugfix/381 pagination errors

### DIFF
--- a/components/global/pagination/pagination-button.tsx
+++ b/components/global/pagination/pagination-button.tsx
@@ -9,6 +9,7 @@ interface PaginationButtonProps {
   children: React.ReactNode;
   active?: boolean;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
 export default function PaginationButton({
@@ -17,16 +18,18 @@ export default function PaginationButton({
   children,
   active,
   onClick,
+  disabled,
 }: PaginationButtonProps) {
   const buttonContent = (
     <Button
       aria-label={typeof children === "string" ? children : undefined}
       className={cn(
-        "flex items-center gap-2 border-black border-",
-        active && "bg-white text-black ",
+        "flex items-center gap-2 border-black border-2",
+        active && "bg-white text-black cursor-default hover:bg-white",
       )}
       size="sm"
       onClick={onClick}
+      disabled={disabled}
     >
       {arrow === "left" && (
         <ChevronLeft style={{ width: "10px", height: "10px" }} />
@@ -38,7 +41,7 @@ export default function PaginationButton({
     </Button>
   );
 
-  if (href) {
+  if (href && !active && !disabled) {
     return (
       <Link href={href} prefetch={true}>
         {buttonContent}

--- a/components/global/pagination/pagination-button.tsx
+++ b/components/global/pagination/pagination-button.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "../../ui/button";
 import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 interface PaginationButtonProps {
   href?: string;
@@ -20,7 +21,10 @@ export default function PaginationButton({
   const buttonContent = (
     <Button
       aria-label={typeof children === "string" ? children : undefined}
-      className={`flex items-center gap-2 ${active ? "bg-primary text-primary-foreground" : ""}`}
+      className={cn(
+        "flex items-center gap-2 border-black border-",
+        active && "bg-white text-black ",
+      )}
       size="sm"
       onClick={onClick}
     >

--- a/components/global/pagination/pagination.tsx
+++ b/components/global/pagination/pagination.tsx
@@ -69,16 +69,22 @@ export default function Pagination({
   return (
     <div className="flex flex-col sm:flex-row gap-4 items-center justify-between w-full mt-4">
       <div className="flex items-center justify-start gap-2">
-        {pageNumber > 1 && (
-          <>
-            <PaginationButton href={getPageHref(1)} arrow="left">
-              First
-            </PaginationButton>
-            <PaginationButton href={getPageHref(pageNumber - 1)} arrow="left">
-              Previous
-            </PaginationButton>
-          </>
-        )}
+        <>
+          <PaginationButton
+            disabled={pageNumber === 1}
+            href={getPageHref(1)}
+            arrow="left"
+          >
+            First
+          </PaginationButton>
+          <PaginationButton
+            disabled={pageNumber === 1}
+            href={getPageHref(pageNumber - 1)}
+            arrow="left"
+          >
+            Previous
+          </PaginationButton>
+        </>
       </div>
 
       <div className="flex items-center justify-center gap-2">
@@ -86,16 +92,22 @@ export default function Pagination({
       </div>
 
       <div className="flex items-center justify-end gap-2">
-        {pageNumber < totalPages && (
-          <>
-            <PaginationButton href={getPageHref(pageNumber + 1)} arrow="right">
-              Next
-            </PaginationButton>
-            <PaginationButton href={getPageHref(totalPages)} arrow="right">
-              Last
-            </PaginationButton>
-          </>
-        )}
+        <>
+          <PaginationButton
+            disabled={pageNumber === totalPages}
+            href={getPageHref(pageNumber + 1)}
+            arrow="right"
+          >
+            Next
+          </PaginationButton>
+          <PaginationButton
+            disabled={pageNumber === totalPages}
+            href={getPageHref(totalPages)}
+            arrow="right"
+          >
+            Last
+          </PaginationButton>
+        </>
       </div>
     </div>
   );

--- a/components/global/pagination/pagination.tsx
+++ b/components/global/pagination/pagination.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import PaginationButton from "./pagination-button";
+import { useRouter, useSearchParams } from "next/navigation";
 
 interface PaginationProps {
   searchParams: Record<string, string>;
@@ -18,10 +19,11 @@ export default function Pagination({
   itemsPerPage,
   parameterName = "p",
   basePath = "",
-  currentPage = 1,
+  currentPage,
 }: PaginationProps) {
   const totalPages = Math.ceil((totalItems || 0) / itemsPerPage);
   const pageNumber = currentPage || Number(searchParams[parameterName]) || 1;
+  const { push } = useRouter();
 
   const getPageHref = useCallback(
     (page: number) => {
@@ -58,6 +60,11 @@ export default function Pagination({
   };
 
   if (totalPages <= 1) return null;
+
+  if (pageNumber > totalPages) {
+    // Redirect to last page if the current page is greater than the total number of pages
+    push(getPageHref(totalPages));
+  }
 
   return (
     <div className="flex flex-col sm:flex-row gap-4 items-center justify-between w-full mt-4">


### PR DESCRIPTION
@holkexyz This PR should resolve the issues with pagination, please have a look.

It also fixes the styling so you know which page you are currently on, and always renders both first and last buttons at the bottom next to pagination to prevent the page numbers from jumping around between pages.

It also redirects you back to the first page when you go beyond the last one. We could just as easily set this to redirect you to the last page, it's up to you.