### PR TITLE
feat: add buy button listing status

### DIFF
--- a/components/hypercert/hypercert-details.tsx
+++ b/components/hypercert/hypercert-details.tsx
@@ -15,6 +15,7 @@ import { InfoSection } from "../global/sections";
 import PageSkeleton from "./page-skeleton";
 import { cache, Suspense } from "react";
 import { getHypercertState } from "@/hypercerts/getHypercertState";
+import { getOrders } from "@/marketplace/getOpenOrders";
 
 function HypercertDetailsNotFound() {
   return <InfoSection>Hypercert not found</InfoSection>;
@@ -38,6 +39,9 @@ export default async function HypercertDetails({
   hypercertId: string;
 }) {
   const hypercert = await getHypercertDetails(hypercertId);
+  const orders = await getOrders({ filter: { hypercertId: hypercertId } });
+
+  const isListed = orders?.data?.length > 0 && orders?.count > 0;
 
   if (!hypercert) {
     return <HypercertDetailsNotFound />;
@@ -57,7 +61,7 @@ export default async function HypercertDetails({
                 {hypercert?.metadata?.name || "[Untitled]"}
               </h1>
               <div className="flex space-x-2">
-                <BuyButton />
+                <BuyButton isListed={isListed} />
                 <MutationButtons hypercert={hypercert} />
               </div>
             </div>

--- a/components/marketplace/buy-button.tsx
+++ b/components/marketplace/buy-button.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 
-export function BuyButton() {
+export function BuyButton({ isListed }: { isListed: boolean }) {
   const handleClick = () => {
     const listingsSection = document.getElementById("marketplace-listings");
     if (listingsSection) {
@@ -12,5 +12,11 @@ export function BuyButton() {
     }
   };
 
-  return <Button onClick={handleClick}>Buy</Button>;
+  return (
+    <Button onClick={handleClick} disabled={!isListed}>
+      Buy
+    </Button>
+  );
 }
+
+export default BuyButton;


### PR DESCRIPTION
Closes #439 
Disable buy button when no marketplace orders exist for the hypercert

- fetch active order inside the `hypercert/hypercert-details`
- pass "isListed" props to `buy-button` component
- disabled `buy-button` when isListed is false
https://www.loom.com/share/48d136940daa40b1b1a348ae54efa5c0?sid=c1faa939-62a5-4ffa-8296-d3590db22eba