### PR TITLE
fix: correct hypercerts count calculation

### DIFF
--- a/hypercerts/getAllHypercerts.ts
+++ b/hypercerts/getAllHypercerts.ts
@@ -192,8 +192,8 @@ export async function getAllHypercerts({
     [],
   );
 
-  const difference = res.hypercerts?.count
-    ? res.hypercerts?.count - data.length
+  const difference = res.hypercerts?.data?.length
+    ? res.hypercerts?.data?.length - data.length
     : 0;
   const totalCount = res.hypercerts?.count
     ? res.hypercerts?.count - difference


### PR DESCRIPTION
Update getAllHypercerts to correctly determine the number of filtered out hypercerts and adjust the total count accordingly