### PR TITLE
chore: inject public client into hypercert client

### DIFF
--- a/hooks/use-hypercert-client.ts
+++ b/hooks/use-hypercert-client.ts
@@ -3,11 +3,16 @@ import { HypercertClient } from "@hypercerts-org/sdk";
 import { useEffect, useState } from "react";
 import { useAccount, useWalletClient } from "wagmi";
 import { ENVIRONMENT, SUPPORTED_CHAINS } from "@/configs/constants";
+import { EvmClientFactory } from "@/lib/evmClient";
 
 export const useHypercertClient = () => {
   const { data: walletClient } = useWalletClient();
   const { isConnected } = useAccount();
   const [client, setClient] = useState<HypercertClient>();
+
+  const publicClient = walletClient?.chain.id
+    ? EvmClientFactory.createClient(walletClient.chain.id)
+    : undefined;
 
   useEffect(() => {
     if (!walletClient || !isConnected) {
@@ -22,6 +27,8 @@ export const useHypercertClient = () => {
         environment: ENVIRONMENT,
         // @ts-ignore - wagmi and viem have different typing
         walletClient,
+        // @ts-ignore - wagmi and viem have different typing
+        publicClient,
       }),
     );
   }, [walletClient, isConnected]);


### PR DESCRIPTION
injecting our own public client into the hypercert client will ensure we use our own rpc url's within the hypercert exchange client. this prevents the viem defaults being used which error out regularly