### PR TITLE
New GitHub actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,34 @@
+name: Build and Test Frontend
+on:
+  pull_request:
+    branches: [ dev, main, release ]
+  push:
+    branches: [ dev, main, release ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '9.2.0'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build frontend
+        run: pnpm build
+
+      - name: Run lint
+        run: pnpm lint

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,35 @@
+name: Create Release PR
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Semantic Release Versioning
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release PR
+        env:
+          GH_TOKEN: ${{ secrets.GHA_CREATE_PR }}
+        run: |
+          gh pr create \
+            --base release \
+            --head main \
+            --title "chore: new release" \
+            --body "Automated PR from main to release" \
+            --label "automated pr"

--- a/lib/evmClient.ts
+++ b/lib/evmClient.ts
@@ -61,7 +61,7 @@ class DrpcProvider implements RpcProvider {
   }
 }
 
-class GlifProvider implements RpcProvider {
+class FVMProvider implements RpcProvider {
   getUrl(chainId: number): string | undefined {
     const urls: Record<number, string> = {
       314: `https://rpc.ankr.com/filecoin`,
@@ -75,7 +75,7 @@ export class EvmClientFactory {
   private static readonly providers: RpcProvider[] = [
     new AlchemyProvider(),
     new InfuraProvider(),
-    new GlifProvider(),
+    new FVMProvider(),
     new DrpcProvider(),
   ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercert-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/test/lib/evmClient.test.ts
+++ b/test/lib/evmClient.test.ts
@@ -96,9 +96,9 @@ describe("RPC Providers", () => {
       expect(url).toContain("infura-key");
     });
 
-    it("should return Glif URL for Filecoin", () => {
+    it("should return ankr.com URL for Filecoin", () => {
       const url = EvmClientFactory.getRpcUrl(314159);
-      expect(url).toContain("glif.io");
+      expect(url).toContain("https://rpc.ankr.com/");
     });
 
     it("should throw error for unsupported chain", () => {

--- a/test/lib/evmClient.test.ts
+++ b/test/lib/evmClient.test.ts
@@ -1,6 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { UnifiedRpcClientFactory } from "@/lib/rpcClientFactory";
-import * as viem from "viem";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/utils/constants", () => ({
   environment: "test",


### PR DESCRIPTION
We are going to rename two of our branches. `main` -> `release` and `dev` -> `main`. More details in issue #473.

I implemented two new actions:
1. Create a new release-to-production PR (targets `release`) when a PR is merged into `main`
2. Build, test and lint the frontend code when a PR is opened against `dev`, `main` or `release`.