### PR TITLE
Amend automatic release PR for current branch structure

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,7 +1,7 @@
 name: Create Release PR
 on:
   push:
-    branches: [ main ]
+    branches: [ dev ]
 
 permissions:
   contents: write
@@ -28,8 +28,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GHA_CREATE_PR }}
         run: |
           gh pr create \
-            --base release \
-            --head main \
+            --base main \
+            --head dev \
             --title "chore: new release" \
-            --body "Automated PR from main to release" \
+            --body "Automated PR from dev to main (release)" \
             --label "automated pr"


### PR DESCRIPTION
We decided to not rename the branches just yet, so this workflow is changed with our current branch structure in place.