### PR TITLE
Safe support for minting a Hypercert

### DIFF
--- a/components/global/extra-content.tsx
+++ b/components/global/extra-content.tsx
@@ -13,6 +13,8 @@ interface ExtraContentProps {
   receipt?: TransactionReceipt;
 }
 
+// TODO: not really reusable for safe. breaks when minting hypercert from safe.
+// We should make this reusable for all strategies.
 export function ExtraContent({
   message = "Your hypercert has been minted successfully!",
   hypercertId,

--- a/hypercerts/EOAMintHypercertStrategy.ts
+++ b/hypercerts/EOAMintHypercertStrategy.ts
@@ -1,0 +1,169 @@
+import { track } from "@vercel/analytics";
+import { waitForTransactionReceipt } from "viem/actions";
+
+import { createExtraContent } from "@/components/global/extra-content";
+import { generateHypercertIdFromReceipt } from "@/lib/generateHypercertIdFromReceipt";
+import { revalidatePathServerAction } from "@/app/actions/revalidatePathServerAction";
+
+import {
+  MintHypercertParams,
+  MintHypercertStrategy,
+} from "./MintHypercertStrategy";
+import { Address, Chain } from "viem";
+import { HypercertClient } from "@hypercerts-org/sdk";
+import { UseWalletClientReturnType } from "wagmi";
+import { useStepProcessDialogContext } from "@/components/global/step-process-dialog";
+import { useQueueMintBlueprint } from "@/blueprints/hooks/queueMintBlueprint";
+
+export class EOAMintHypercertStrategy extends MintHypercertStrategy {
+  constructor(
+    protected address: Address,
+    protected chain: Chain,
+    protected client: HypercertClient,
+    protected dialogContext: ReturnType<typeof useStepProcessDialogContext>,
+    protected queueMintBlueprint: ReturnType<typeof useQueueMintBlueprint>,
+    protected walletClient: UseWalletClientReturnType,
+  ) {
+    super(address, chain, client, dialogContext, walletClient);
+  }
+
+  // FIXME: this is a long ass method. Break it down into smaller ones.
+  async execute({
+    metaData,
+    units,
+    transferRestrictions,
+    allowlistRecords,
+    blueprintId,
+  }: MintHypercertParams) {
+    const { setDialogStep, setSteps, setOpen, setTitle, setExtraContent } =
+      this.dialogContext;
+    const { mutateAsync: queueMintBlueprint } = this.queueMintBlueprint;
+    const { data: walletClient } = this.walletClient;
+
+    if (!this.client) {
+      setOpen(false);
+      throw new Error("No client found");
+    }
+
+    const isBlueprint = !!blueprintId;
+    setOpen(true);
+    setSteps([
+      { id: "preparing", description: "Preparing to mint hypercert..." },
+      { id: "minting", description: "Minting hypercert on-chain..." },
+      ...(isBlueprint
+        ? [{ id: "blueprint", description: "Queueing blueprint mint..." }]
+        : []),
+      { id: "confirming", description: "Waiting for on-chain confirmation" },
+      { id: "route", description: "Creating your new hypercert's link..." },
+      { id: "done", description: "Minting complete!" },
+    ]);
+    setTitle("Minting hypercert");
+    await setDialogStep("preparing", "active");
+    console.log("preparing...");
+
+    let hash;
+    try {
+      await setDialogStep("minting", "active");
+      console.log("minting...");
+      hash = await this.client.mintHypercert({
+        metaData,
+        totalUnits: units,
+        transferRestriction: transferRestrictions,
+        allowList: allowlistRecords,
+      });
+    } catch (error: unknown) {
+      console.error("Error minting hypercert:", error);
+      throw new Error(
+        `Failed to mint hypercert: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+
+    if (!hash) {
+      throw new Error("No transaction hash returned");
+    }
+
+    if (blueprintId) {
+      try {
+        await setDialogStep("blueprint", "active");
+        await queueMintBlueprint({
+          blueprintId,
+          txHash: hash,
+        });
+      } catch (error: unknown) {
+        console.error("Error queueing blueprint mint:", error);
+        throw new Error(
+          `Failed to queue blueprint mint: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+      }
+    }
+    await setDialogStep("confirming", "active");
+    console.log("Mint submitted", {
+      hash,
+    });
+    track("Mint submitted", {
+      hash,
+    });
+    let receipt;
+
+    try {
+      receipt = await waitForTransactionReceipt(walletClient!, {
+        confirmations: 3,
+        hash,
+      });
+      console.log({ receipt });
+    } catch (error: unknown) {
+      console.error("Error waiting for transaction receipt:", error);
+      await setDialogStep(
+        "confirming",
+        "error",
+        error instanceof Error ? error.message : "Unknown error",
+      );
+      throw new Error(
+        `Failed to confirm transaction: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+
+    if (receipt?.status === "reverted") {
+      throw new Error("Transaction reverted: Minting failed");
+    }
+
+    await setDialogStep("route", "active");
+
+    let hypercertId;
+    try {
+      hypercertId = generateHypercertIdFromReceipt(receipt, this.chain.id);
+      console.log("Mint completed", {
+        hypercertId: hypercertId || "not found",
+      });
+      track("Mint completed", {
+        hypercertId: hypercertId || "not found",
+      });
+      console.log({ hypercertId });
+    } catch (error) {
+      console.error("Error generating hypercert ID:", error);
+      await setDialogStep(
+        "route",
+        "error",
+        error instanceof Error ? error.message : "Unknown error",
+      );
+    }
+
+    const extraContent = createExtraContent({
+      receipt,
+      hypercertId,
+      chain: this.chain,
+    });
+    setExtraContent(extraContent);
+
+    await setDialogStep("done", "completed");
+
+    // TODO: Clean up these revalidations.
+    // https://github.com/hypercerts-org/hypercerts-app/pull/484#discussion_r2011898721
+    await revalidatePathServerAction([
+      "/collections",
+      "/collections/edit/[collectionId]",
+      `/profile/${this.address}`,
+      { path: `/`, type: "layout" },
+    ]);
+  }
+}

--- a/hypercerts/MintHypercertStrategy.ts
+++ b/hypercerts/MintHypercertStrategy.ts
@@ -1,0 +1,30 @@
+import { Address, Chain } from "viem";
+import {
+  HypercertClient,
+  HypercertMetadata,
+  TransferRestrictions,
+  AllowlistEntry,
+} from "@hypercerts-org/sdk";
+import { UseWalletClientReturnType } from "wagmi";
+
+import { useStepProcessDialogContext } from "@/components/global/step-process-dialog";
+
+export interface MintHypercertParams {
+  metaData: HypercertMetadata;
+  units: bigint;
+  transferRestrictions: TransferRestrictions;
+  allowlistRecords?: AllowlistEntry[] | string;
+  blueprintId?: number;
+}
+
+export abstract class MintHypercertStrategy {
+  constructor(
+    protected address: Address,
+    protected chain: Chain,
+    protected client: HypercertClient,
+    protected dialogContext: ReturnType<typeof useStepProcessDialogContext>,
+    protected walletClient: UseWalletClientReturnType,
+  ) {}
+
+  abstract execute(params: MintHypercertParams): Promise<void>;
+}

--- a/hypercerts/SafeMintHypercertStrategy.tsx
+++ b/hypercerts/SafeMintHypercertStrategy.tsx
@@ -1,0 +1,93 @@
+import {
+  MintHypercertStrategy,
+  MintHypercertParams,
+} from "./MintHypercertStrategy";
+
+import { Button } from "@/components/ui/button";
+import { generateSafeAppLink } from "@/lib/utils";
+import { ExternalLink } from "lucide-react";
+import { Chain } from "viem";
+
+export class SafeMintHypercertStrategy extends MintHypercertStrategy {
+  async execute({
+    metaData,
+    units,
+    transferRestrictions,
+    allowlistRecords,
+  }: MintHypercertParams) {
+    const { setDialogStep, setSteps, setOpen, setTitle, setExtraContent } =
+      this.dialogContext;
+
+    if (!this.client) {
+      setOpen(false);
+      throw new Error("No client found");
+    }
+
+    setOpen(true);
+    setTitle("Minting hypercert");
+    setSteps([
+      { id: "preparing", description: "Preparing to mint hypercert..." },
+      { id: "submitting", description: "Submitting to Safe..." },
+      { id: "queued", description: "Transaction queued in Safe" },
+    ]);
+
+    await setDialogStep("preparing", "active");
+
+    try {
+      await setDialogStep("submitting", "active");
+      await this.client.mintHypercert({
+        metaData,
+        totalUnits: units,
+        transferRestriction: transferRestrictions,
+        allowList: allowlistRecords,
+        overrides: {
+          safeAddress: this.address as `0x${string}`,
+        },
+      });
+
+      await setDialogStep("queued", "completed");
+
+      setExtraContent(() => (
+        <DialogFooter chain={this.chain} safeAddress={this.address} />
+      ));
+    } catch (error) {
+      console.error(error);
+      await setDialogStep(
+        "submitting",
+        "error",
+        error instanceof Error ? error.message : "Unknown error",
+      );
+      throw error;
+    }
+  }
+}
+
+function DialogFooter({
+  chain,
+  safeAddress,
+}: {
+  chain: Chain;
+  safeAddress: string;
+}) {
+  return (
+    <div className="flex flex-col space-y-2">
+      <p className="text-lg font-medium">Success</p>
+      <p className="text-sm font-medium">
+        We&apos;ve submitted the transaction requests to the connected Safe.
+      </p>
+      <div className="flex space-x-4 py-4 justify-center">
+        {chain && (
+          <Button asChild>
+            <a
+              href={generateSafeAppLink(chain, safeAddress as `0x${string}`)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View Safe <ExternalLink size={14} className="ml-2" />
+            </a>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/hypercerts/hooks/useMintHypercert.ts
+++ b/hypercerts/hooks/useMintHypercert.ts
@@ -1,27 +1,15 @@
-import { useStepProcessDialogContext } from "@/components/global/step-process-dialog";
-import { toast } from "@/components/ui/use-toast";
-import { useHypercertClient } from "@/hooks/use-hypercert-client";
-import { generateHypercertIdFromReceipt } from "@/lib/generateHypercertIdFromReceipt";
-import {
-  AllowlistEntry,
-  HypercertMetadata,
-  TransferRestrictions,
-} from "@hypercerts-org/sdk";
 import { useMutation } from "@tanstack/react-query";
-import { waitForTransactionReceipt } from "viem/actions";
-import { useAccount, useWalletClient } from "wagmi";
-import { useQueueMintBlueprint } from "@/blueprints/hooks/queueMintBlueprint";
-import { revalidatePathServerAction } from "@/app/actions/revalidatePathServerAction";
-import { track } from "@vercel/analytics";
-import { createExtraContent } from "@/components/global/extra-content";
+
+import { toast } from "@/components/ui/use-toast";
+import { useStepProcessDialogContext } from "@/components/global/step-process-dialog";
+
+import { MintHypercertParams } from "../MintHypercertStrategy";
+
+import { useMintHypercertStrategy } from "./useMintHypercertStrategy";
 
 export const useMintHypercert = () => {
-  const { client } = useHypercertClient();
-  const { data: walletClient } = useWalletClient();
-  const { chain, address } = useAccount();
-  const { setDialogStep, setSteps, setOpen, setTitle, setExtraContent } =
-    useStepProcessDialogContext();
-  const { mutateAsync: queueMintBlueprint } = useQueueMintBlueprint();
+  const { setDialogStep } = useStepProcessDialogContext();
+  const getStrategy = useMintHypercertStrategy();
 
   return useMutation({
     mutationKey: ["MINT_HYPERCERT"],
@@ -34,147 +22,9 @@ export const useMintHypercert = () => {
         duration: 5000,
       });
     },
-    onSuccess: async (hash) => {
-      await setDialogStep("confirming", "active");
-      console.log("Mint submitted", {
-        hash,
-      });
-      track("Mint submitted", {
-        hash,
-      });
-      let receipt;
-
-      try {
-        receipt = await waitForTransactionReceipt(walletClient!, {
-          confirmations: 3,
-          hash,
-        });
-        console.log({ receipt });
-      } catch (error: unknown) {
-        console.error("Error waiting for transaction receipt:", error);
-        await setDialogStep(
-          "confirming",
-          "error",
-          error instanceof Error ? error.message : "Unknown error",
-        );
-        throw new Error(
-          `Failed to confirm transaction: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-      }
-
-      if (receipt?.status === "reverted") {
-        throw new Error("Transaction reverted: Minting failed");
-      }
-
-      await setDialogStep("route", "active");
-
-      let hypercertId;
-      try {
-        hypercertId = generateHypercertIdFromReceipt(receipt, chain?.id!);
-        console.log("Mint completed", {
-          hypercertId: hypercertId || "not found",
-        });
-        track("Mint completed", {
-          hypercertId: hypercertId || "not found",
-        });
-        console.log({ hypercertId });
-      } catch (error) {
-        console.error("Error generating hypercert ID:", error);
-        await setDialogStep(
-          "route",
-          "error",
-          error instanceof Error ? error.message : "Unknown error",
-        );
-      }
-
-      const extraContent = createExtraContent({
-        receipt,
-        hypercertId,
-        chain: chain!,
-      });
-      setExtraContent(extraContent);
-
-      await setDialogStep("done", "completed");
-
-      await revalidatePathServerAction([
-        "/collections",
-        "/collections/edit/[collectionId]",
-        `/profile/${address}`,
-        { path: `/`, type: "layout" },
-      ]);
-      return { hypercertId, receipt, chain };
-    },
-    mutationFn: async ({
-      metaData,
-      units,
-      transferRestrictions,
-      allowlistRecords,
-      blueprintId,
-    }: {
-      metaData: HypercertMetadata;
-      units: bigint;
-      transferRestrictions: TransferRestrictions;
-      allowlistRecords?: AllowlistEntry[] | string;
-      blueprintId?: number;
-    }) => {
-      if (!client) {
-        setOpen(false);
-        throw new Error("No client found");
-      }
-
-      const isBlueprint = !!blueprintId;
-      setOpen(true);
-      setSteps([
-        { id: "preparing", description: "Preparing to mint hypercert..." },
-        { id: "minting", description: "Minting hypercert on-chain..." },
-        ...(isBlueprint
-          ? [{ id: "blueprint", description: "Queueing blueprint mint..." }]
-          : []),
-        { id: "confirming", description: "Waiting for on-chain confirmation" },
-        { id: "route", description: "Creating your new hypercert's link..." },
-        { id: "done", description: "Minting complete!" },
-      ]);
-      setTitle("Minting hypercert");
-      await setDialogStep("preparing", "active");
-      console.log("preparing...");
-
-      let hash;
-      try {
-        await setDialogStep("minting", "active");
-        console.log("minting...");
-        hash = await client.mintHypercert({
-          metaData,
-          totalUnits: units,
-          transferRestriction: transferRestrictions,
-          allowList: allowlistRecords,
-        });
-      } catch (error: unknown) {
-        console.error("Error minting hypercert:", error);
-        throw new Error(
-          `Failed to mint hypercert: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-      }
-
-      if (!hash) {
-        throw new Error("No transaction hash returned");
-      }
-
-      if (blueprintId) {
-        try {
-          await setDialogStep("blueprint", "active");
-          await queueMintBlueprint({
-            blueprintId,
-            txHash: hash,
-          });
-        } catch (error: unknown) {
-          console.error("Error queueing blueprint mint:", error);
-          throw new Error(
-            `Failed to queue blueprint mint: ${error instanceof Error ? error.message : "Unknown error"}`,
-          );
-        }
-      }
-
-      return hash;
+    mutationFn: async (params: MintHypercertParams) => {
+      const strategy = getStrategy(params.blueprintId);
+      return strategy.execute(params);
     },
   });
 };

--- a/hypercerts/hooks/useMintHypercertStrategy.ts
+++ b/hypercerts/hooks/useMintHypercertStrategy.ts
@@ -1,0 +1,52 @@
+import { isAddress } from "viem";
+import { useAccount, useWalletClient } from "wagmi";
+
+import { useAccountStore } from "@/lib/account-store";
+import { useHypercertClient } from "@/hooks/use-hypercert-client";
+import { useQueueMintBlueprint } from "@/blueprints/hooks/queueMintBlueprint";
+import { useStepProcessDialogContext } from "@/components/global/step-process-dialog";
+
+import { EOAMintHypercertStrategy } from "../EOAMintHypercertStrategy";
+import { MintHypercertStrategy } from "../MintHypercertStrategy";
+import { SafeMintHypercertStrategy } from "../SafeMintHypercertStrategy";
+
+export const useMintHypercertStrategy = () => {
+  const { address, chain } = useAccount();
+  const { client } = useHypercertClient();
+  const { selectedAccount } = useAccountStore();
+  const dialogContext = useStepProcessDialogContext();
+  const queueMintBlueprint = useQueueMintBlueprint();
+  const walletClient = useWalletClient();
+
+  return (blueprintId?: number): MintHypercertStrategy => {
+    const activeAddress =
+      selectedAccount?.address || (address as `0x${string}`);
+
+    if (!activeAddress || !isAddress(activeAddress))
+      throw new Error("No address found");
+    if (!chain) throw new Error("No chain found");
+    if (!client) throw new Error("No HypercertClient found");
+    if (!walletClient) throw new Error("No walletClient found");
+    if (!dialogContext) throw new Error("No dialogContext found");
+
+    // If there's a blueprintId in the search params, we can't use the Safe strategy.
+    if (selectedAccount?.type === "safe" && !blueprintId) {
+      return new SafeMintHypercertStrategy(
+        activeAddress,
+        chain,
+        client,
+        dialogContext,
+        walletClient,
+      );
+    }
+
+    return new EOAMintHypercertStrategy(
+      activeAddress,
+      chain,
+      client,
+      dialogContext,
+      queueMintBlueprint,
+      walletClient,
+    );
+  };
+};

--- a/marketplace/SafeBuyFractionalStrategy.tsx
+++ b/marketplace/SafeBuyFractionalStrategy.tsx
@@ -26,17 +26,17 @@ export class SafeBuyFractionalStrategy extends BuyFractionalStrategy {
       setExtraContent,
     } = this.dialogContext;
     if (!this.exchangeClient) {
-      this.dialogContext.setOpen(false);
+      setOpen(false);
       throw new Error("No client");
     }
 
     if (!this.chainId) {
-      this.dialogContext.setOpen(false);
+      setOpen(false);
       throw new Error("No chain id");
     }
 
     if (!this.walletClient.data) {
-      this.dialogContext.setOpen(false);
+      setOpen(false);
       throw new Error("No wallet client data");
     }
 

--- a/marketplace/SafeBuyFractionalStrategy.tsx
+++ b/marketplace/SafeBuyFractionalStrategy.tsx
@@ -1,13 +1,13 @@
 import { Currency, Taker } from "@hypercerts-org/marketplace-sdk";
 import { zeroAddress } from "viem";
 
-import { SUPPORTED_CHAINS } from "@/configs/constants";
 import { decodeContractError } from "@/lib/decodeContractError";
-
 import { ExtraContent } from "@/components/global/extra-content";
+import { SUPPORTED_CHAINS } from "@/configs/constants";
+
 import { BuyFractionalStrategy } from "./BuyFractionalStrategy";
-import { MarketplaceOrder } from "./types";
 import { getCurrencyByAddress } from "./utils";
+import { MarketplaceOrder } from "./types";
 
 export class SafeBuyFractionalStrategy extends BuyFractionalStrategy {
   async execute({

--- a/marketplace/SafeBuyFractionalStrategy.tsx
+++ b/marketplace/SafeBuyFractionalStrategy.tsx
@@ -14,14 +14,10 @@ export class SafeBuyFractionalStrategy extends BuyFractionalStrategy {
     order,
     unitAmount,
     pricePerUnit,
-    hypercertName,
-    totalUnitsInHypercert,
   }: {
     order: MarketplaceOrder;
     unitAmount: bigint;
     pricePerUnit: string;
-    hypercertName?: string | null;
-    totalUnitsInHypercert?: bigint;
   }) {
     const {
       setDialogStep: setStep,

--- a/marketplace/SafeBuyFractionalStrategy.tsx
+++ b/marketplace/SafeBuyFractionalStrategy.tsx
@@ -40,7 +40,6 @@ export class SafeBuyFractionalStrategy extends BuyFractionalStrategy {
       throw new Error("No wallet client data");
     }
 
-    // TODO: we might have to change some steps here
     setSteps([
       {
         id: "Setting up order execution",
@@ -107,8 +106,6 @@ export class SafeBuyFractionalStrategy extends BuyFractionalStrategy {
           order.currency as `0x${string}`,
         );
 
-        // TODO: if this is not approved yet, we need to create a Safe TX and drop out of this
-        // dialog early, so that the next invocation runs through this check without stopping.
         if (currentAllowance < totalPrice) {
           console.debug("Approving ERC20");
           await this.exchangeClient.approveErc20Safe(
@@ -128,12 +125,11 @@ export class SafeBuyFractionalStrategy extends BuyFractionalStrategy {
       throw new Error("Approval error");
     }
 
-    // TODO: this whole step should probably not be here
     try {
       await setStep("Transfer manager");
       const isTransferManagerApproved =
         await this.exchangeClient.isTransferManagerApprovedSafe(this.address);
-      // FIXME: this shouldn't be here, unless we're missing something
+
       if (!isTransferManagerApproved) {
         console.debug("Approving transfer manager");
         await this.exchangeClient.grantTransferManagerApprovalSafe(

--- a/marketplace/useBuyFractionalStrategy.ts
+++ b/marketplace/useBuyFractionalStrategy.ts
@@ -8,7 +8,7 @@ import { useStepProcessDialogContext } from "@/components/global/step-process-di
 import { BuyFractionalStrategy } from "./BuyFractionalStrategy";
 import { EOABuyFractionalStrategy } from "./EOABuyFractionalStrategy";
 import { SafeBuyFractionalStrategy } from "./SafeBuyFractionalStrategy";
-import { Address, getAddress, isAddress } from "viem";
+import { getAddress, isAddress } from "viem";
 
 export const useBuyFractionalStrategy = (): (() => BuyFractionalStrategy) => {
   const { address, chainId } = useAccount();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@hypercerts-org/contracts": "2.0.0-alpha.12",
     "@hypercerts-org/marketplace-sdk": " 0.5.0-alpha.0",
-    "@hypercerts-org/sdk": "2.5.0-beta.6",
+    "@hypercerts-org/sdk": "2.6.0",
     "@next/env": "^14.2.10",
     "@openzeppelin/merkle-tree": "^1.0.6",
     "@radix-ui/react-accordion": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@hookform/resolvers": "^3.3.4",
     "@hypercerts-org/contracts": "2.0.0-alpha.12",
-    "@hypercerts-org/marketplace-sdk": " 0.5.0-alpha.0",
+    "@hypercerts-org/marketplace-sdk": "0.5.0-alpha.0",
     "@hypercerts-org/sdk": "2.6.0",
     "@next/env": "^14.2.10",
     "@openzeppelin/merkle-tree": "^1.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ' 0.5.0-alpha.0'
         version: 0.5.0-alpha.0(@safe-global/api-kit@2.5.9(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(@safe-global/protocol-kit@5.2.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(@swc/helpers@0.5.5)(bufferutil@4.0.9)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(graphql@16.10.0)(rollup@4.31.0)(ts-node@10.9.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(@types/node@20.17.14)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@hypercerts-org/sdk':
-        specifier: 2.5.0-beta.6
-        version: 2.5.0-beta.6(@swc/helpers@0.5.5)(bufferutil@4.0.9)(graphql@16.10.0)(rollup@4.31.0)(ts-node@10.9.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(@types/node@20.17.14)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.10)
+        specifier: 2.6.0
+        version: 2.6.0(@safe-global/api-kit@2.5.9(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(@safe-global/protocol-kit@5.2.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(@safe-global/types-kit@1.0.2(typescript@5.7.3)(zod@3.24.1))(@swc/helpers@0.5.5)(bufferutil@4.0.9)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(graphql@16.10.0)(rollup@4.31.0)(ts-node@10.9.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(@types/node@20.17.14)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@next/env':
         specifier: ^14.2.10
         version: 14.2.23
@@ -829,8 +829,13 @@ packages:
   '@hypercerts-org/sdk@2.4.0':
     resolution: {integrity: sha512-9vxQW3zBwi3WCOUBMwU1fWEk3z29eyxtDWlaIS7jdUlGwnCcN9IkPzIk7w/jHO96yiH8+vcL/EWFvOp06mtXAw==}
 
-  '@hypercerts-org/sdk@2.5.0-beta.6':
-    resolution: {integrity: sha512-v24hjmCwkL2/lkbQbYxzepLAJOc2SwfHVBoADNcdcT+/s7Fvpq5I+MddlWHYDcBLacPhyF3k+F9O/tkwvofY1g==}
+  '@hypercerts-org/sdk@2.6.0':
+    resolution: {integrity: sha512-uq+9WzgW+GWazEKTUEhUPZr8sTxhORaNI6DfRfDTZ8w0FJtPEXSSLt5mr9x5VN8EghM1NsPvKzf38jkO8wBkZg==}
+    peerDependencies:
+      '@safe-global/api-kit': ^2.5.7
+      '@safe-global/protocol-kit': ^5.2.0
+      '@safe-global/types-kit': ^1.0.4
+      ethers: ^6.6.2
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -7276,17 +7281,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hypercerts-org/sdk@2.5.0-beta.6(@swc/helpers@0.5.5)(bufferutil@4.0.9)(graphql@16.10.0)(rollup@4.31.0)(ts-node@10.9.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(@types/node@20.17.14)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.10)':
+  '@hypercerts-org/sdk@2.6.0(@safe-global/api-kit@2.5.9(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(@safe-global/protocol-kit@5.2.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(@safe-global/types-kit@1.0.2(typescript@5.7.3)(zod@3.24.1))(@swc/helpers@0.5.5)(bufferutil@4.0.9)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(graphql@16.10.0)(rollup@4.31.0)(ts-node@10.9.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(@types/node@20.17.14)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
       '@hypercerts-org/contracts': 2.0.0-alpha.12(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(@types/node@20.17.14)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@openzeppelin/merkle-tree': 1.0.7
+      '@safe-global/api-kit': 2.5.9(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@safe-global/protocol-kit': 5.2.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@safe-global/types-kit': 1.0.2(typescript@5.7.3)(zod@3.24.1)
       '@swc/core': 1.10.9(@swc/helpers@0.5.5)
       ajv: 8.17.1
       axios: 1.7.9
       dotenv: 16.4.7
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       rollup-plugin-swc3: 0.11.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(rollup@4.31.0)
-      viem: 2.23.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       zod: 3.24.1
     transitivePeerDependencies:
       - '@swc/helpers'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: 2.0.0-alpha.12
         version: 2.0.0-alpha.12(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(@types/node@20.17.14)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@hypercerts-org/marketplace-sdk':
-        specifier: ' 0.5.0-alpha.0'
+        specifier: 0.5.0-alpha.0
         version: 0.5.0-alpha.0(@safe-global/api-kit@2.5.9(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(@safe-global/protocol-kit@5.2.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(@swc/helpers@0.5.5)(bufferutil@4.0.9)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(graphql@16.10.0)(rollup@4.31.0)(ts-node@10.9.2(@swc/core@1.10.9(@swc/helpers@0.5.5))(@types/node@20.17.14)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@hypercerts-org/sdk':
         specifier: 2.6.0


### PR DESCRIPTION
This PR adds support for the user to mint a Hypercert using their Safe.

By passing the Safe address into the SDK function (via the `overrides` object) the Safe flow is invoked. The minting dialog now shows only the steps to propose a Safe transaction and invokes `mintHypercert()` on the Hypercerts SDK.

You can see a Safe transaction that was created with the new Hypercerts SDK version and the changes from this PR [here](https://app.safe.global/transactions/tx?id=multisig_0x6C622Ca31a755b4A543f1FE1dB26A666A468Fda8_0x4c7372ba41b279452ee012a0a619de00873ec4e556b0e8feac38bf6fb4c32236&safe=sep:0x6C622Ca31a755b4A543f1FE1dB26A666A468Fda8).