### PR TITLE
Keep selected Safe after refresh

### DIFF
--- a/lib/account-store.ts
+++ b/lib/account-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 export type AccountType = "eoa" | "safe";
 
@@ -12,10 +13,17 @@ interface AccountState {
   setSelectedAccount: (account: Account | null) => void;
 }
 
-export const useAccountStore = create<AccountState>((set) => ({
-  selectedAccount: null,
-  setSelectedAccount: (account) => set({ selectedAccount: account }),
-}));
+export const useAccountStore = create<AccountState>()(
+  persist(
+    (set) => ({
+      selectedAccount: null,
+      setSelectedAccount: (account) => set({ selectedAccount: account }),
+    }),
+    {
+      name: "selected-account-storage",
+    },
+  ),
+);
 
 export function selectWalletAccount(address: string) {
   useAccountStore.setState({


### PR DESCRIPTION
Without this patch, when having selected a Safe account and refreshing the page, the connected EOA is selected again. Users will have to re-select the Safe, if they want to continue acting on behalf of the Safe.

This patch add persistence to the user account selection using zustand.