### PR TITLE
fix: handle error when creating public client in useHypercertClient hook

### DIFF
--- a/hooks/use-hypercert-client.ts
+++ b/hooks/use-hypercert-client.ts
@@ -4,15 +4,21 @@ import { useEffect, useState } from "react";
 import { useAccount, useWalletClient } from "wagmi";
 import { ENVIRONMENT, SUPPORTED_CHAINS } from "@/configs/constants";
 import { EvmClientFactory } from "@/lib/evmClient";
+import { PublicClient } from "viem";
 
 export const useHypercertClient = () => {
   const { data: walletClient } = useWalletClient();
   const { isConnected } = useAccount();
   const [client, setClient] = useState<HypercertClient>();
 
-  const publicClient = walletClient?.chain.id
-    ? EvmClientFactory.createClient(walletClient.chain.id)
-    : undefined;
+  let publicClient: PublicClient | undefined;
+  try {
+    publicClient = walletClient?.chain.id
+      ? EvmClientFactory.createClient(walletClient.chain.id)
+      : undefined;
+  } catch (error) {
+    console.error(`Error creating public client: ${error}`);
+  }
 
   useEffect(() => {
     if (!walletClient || !isConnected) {


### PR DESCRIPTION
Added error handling for the public client creation process to prevent crashes when the wallet client is not properly initialized.